### PR TITLE
maxPeerCount and requiredPeerCount for private data improved

### DIFF
--- a/e2e/__snapshots__/extendConfig.test.ts.snap
+++ b/e2e/__snapshots__/extendConfig.test.ts.snap
@@ -264,10 +264,10 @@ Object {
         },
         Object {
           "blockToLive": 0,
-          "maxPeerCount": 0,
+          "maxPeerCount": 1,
           "name": "org2-collection",
           "policy": "OR('Org2MSP.member')",
-          "requiredPeerCount": 0,
+          "requiredPeerCount": 1,
         },
       ],
       "privateDataConfigFile": "collections/chaincode1.json",

--- a/e2e/__snapshots__/fabrica-config-hlf1.3-2orgs-1chaincode-private-data.json.test.ts.snap
+++ b/e2e/__snapshots__/fabrica-config-hlf1.3-2orgs-1chaincode-private-data.json.test.ts.snap
@@ -18,8 +18,8 @@ exports[`samples/fabrica-config-hlf1.3-2orgs-1chaincode-private-data.json should
   {
     \\"name\\": \\"org2-collection\\",
     \\"policy\\": \\"OR('Org2MSP.member')\\",
-    \\"requiredPeerCount\\": 0,
-    \\"maxPeerCount\\": 0,
+    \\"requiredPeerCount\\": 1,
+    \\"maxPeerCount\\": 1,
     \\"blockToLive\\": 0
   }
 ]"

--- a/src/extend-config/configTransformers.ts
+++ b/src/extend-config/configTransformers.ts
@@ -40,7 +40,7 @@ const createPrivateCollectionConfig = (
   const policy = `OR(${relevantOrgs.map((o) => `'${o.mspName}.member'`).join(",")})`;
   const peerCounts = relevantOrgs.map((o) => (o.anchorPeers || []).length);
   const maxPeerCount = peerCounts.reduce((a, b) => a + b, 0);
-  const requiredPeerCount = maxPeerCount <= 2 ? Math.max(1, maxPeerCount) : Math.trunc(maxPeerCount / 2);
+  const requiredPeerCount = peerCounts.reduce((a, b) => Math.min(a, b), maxPeerCount) || 1;
 
   const memberOnlyRead = version(fabricVersion).isGreaterOrEqual("1.4.0") ? { memberOnlyRead: true } : {};
   const memberOnlyWrite = version(fabricVersion).isGreaterOrEqual("2.0.0") ? { memberOnlyWrite: true } : {};

--- a/src/extend-config/configTransformers.ts
+++ b/src/extend-config/configTransformers.ts
@@ -38,12 +38,9 @@ const createPrivateCollectionConfig = (
   }
 
   const policy = `OR(${relevantOrgs.map((o) => `'${o.mspName}.member'`).join(",")})`;
-  const peerCounts = relevantOrgs.map((o) => (o.peers || []).length);
-  const totalPeers = peerCounts.reduce((a, b) => a + b, 0);
-
-  // We need enough peers to exceed one org (max in org + 1) and up to totalPeers - 1
-  const requiredPeerCount = Math.min(totalPeers - 1, peerCounts.reduce((a, b) => Math.max(a, b), 0) + 1);
-  const maxPeerCount = Math.max(requiredPeerCount, Math.min(requiredPeerCount * 2, totalPeers - 1));
+  const peerCounts = relevantOrgs.map((o) => (o.anchorPeers || []).length);
+  const maxPeerCount = peerCounts.reduce((a, b) => a + b, 0);
+  const requiredPeerCount = maxPeerCount <= 2 ? Math.max(1, maxPeerCount) : Math.trunc(maxPeerCount / 2);
 
   const memberOnlyRead = version(fabricVersion).isGreaterOrEqual("1.4.0") ? { memberOnlyRead: true } : {};
   const memberOnlyWrite = version(fabricVersion).isGreaterOrEqual("2.0.0") ? { memberOnlyWrite: true } : {};


### PR DESCRIPTION
Why: Private data for Fabric v2 seems to disseminate only to anchor peers from the current org 🤔 